### PR TITLE
fixed issue where ssm document was failing immediately

### DIFF
--- a/templates/sios-protection-suite.template
+++ b/templates/sios-protection-suite.template
@@ -829,6 +829,7 @@ Resources:
             systemctl start amazon-ssm-agent
             sleep 10
           done
+          sleep 300
           aws ssm start-automation-execution \
             --document-name ${SSMDocumentSPSLS4} \
             --region ${AWS::Region} \


### PR DESCRIPTION
Aws api call was returning null due to lack of tag on SPSLNode2.

So I added a wait just before deploying the ssm automation document.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
